### PR TITLE
Realize and test user creation endpoint (POST /api/users)

### DIFF
--- a/DTOs/CreateUserRequestDto.cs
+++ b/DTOs/CreateUserRequestDto.cs
@@ -22,7 +22,6 @@ namespace UserApi.DTOs {
         [Range(0, 2, ErrorMessage = "Gender must be 0, 1 or 2")]
         public int Gender { get; set; }
 
-        [Required(ErrorMessage = "Birtday is required")]
         public DateTime? Birthday { get; set; }
 
         [Required(ErrorMessage = "Admin status is required")]

--- a/DTOs/CreateUserRequestDto.cs
+++ b/DTOs/CreateUserRequestDto.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace UserApi.DTOs {
+    public class CreateUserRequestDto {
+
+        [Required(ErrorMessage = "Login is required")]
+        [StringLength(40, MinimumLength = 3, ErrorMessage = "Login must be between 3 and 40 characters")]
+        [RegularExpression("^[a-zA-Z0-9]*$", ErrorMessage = "Login can only contain latin letters and numbers")]
+        public required string Login { get; set; }
+
+        [Required(ErrorMessage = "Password is required")]
+        [StringLength(80, MinimumLength = 5, ErrorMessage = "Password must be between 5 and 80 characters")]
+        [RegularExpression("^[a-zA-Z0-9]*$", ErrorMessage = "Password can only contain latin letters and numbers")]
+        public required string Password { get; set; }
+
+        [Required(ErrorMessage = "Name is required")]
+        [StringLength(40, ErrorMessage = "Name cannot be longer than 100 characters")]
+        [RegularExpression(@"^[a-zA-Zа-яА-ЯёЁ\s]*$", ErrorMessage = "Name can only contain latin and cyrillic letters and spaces")]
+        public required string Name { get; set; }
+
+        [Required(ErrorMessage = "Gender is required")]
+        [Range(0, 2, ErrorMessage = "Gender must be 0, 1 or 2")]
+        public int Gender { get; set; }
+
+        [Required(ErrorMessage = "Birtday is required")]
+        public DateTime? Birthday { get; set; }
+
+        [Required(ErrorMessage = "Admin status is required")]
+        public bool Admin { get; set; }
+    }
+}

--- a/DTOs/UserResponseDto.cs
+++ b/DTOs/UserResponseDto.cs
@@ -1,0 +1,12 @@
+namespace UserApi.DTOs {
+    public class UserResponseDto {
+        public Guid Guid { get; set; }
+        public required string Login { get; set; }
+        public required string Name { get; set; }
+        public int Gender { get; set; }
+        public DateTime? Birthday { get; set; }
+        public bool Admin { get; set; }
+        public DateTime CreatedOn { get; set; }
+        public bool IsActive { get; set; } // на основе RevokeOn
+    }
+}

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -2,16 +2,16 @@
 namespace UserApi.Models {
     public class User {
         public Guid Guid { get; set; }
-        public string Login { get; set; }
-        public string Password { get; set; }
-        public string Name { get; set; }
+        public required string Login { get; set; }
+        public required string Password { get; set; }
+        public required string Name { get; set; }
         public int Gender { get; set; }
         public DateTime? Birthday { get; set; }
         public bool Admin { get; set; }
         public DateTime CreatedOn { get; set; }
-        public string CreatedBy { get; set; }
+        public required string CreatedBy { get; set; }
         public DateTime ModifiedOn { get; set; }
-        public string ModifiedBy { get; set; }
+        public required string ModifiedBy { get; set; }
         public DateTime? RevokedOn { get; set; }
         public string? RevokedBy { get; set; }
         

--- a/Services/IUserService.cs
+++ b/Services/IUserService.cs
@@ -1,10 +1,11 @@
 using UserApi.Models;
+using UserApi.DTOs;
 
 namespace UserApi.Services 
 {
     public interface IUserService 
     {
-        Task<User?> CreateUserAsync(string login, string password, string name, int gender, DateTime? birthday, bool isAdmin, string createdBy);
+        Task<User?> CreateUserAsync(CreateUserRequestDto createUserDto, string createdBy);
 
         Task<IEnumerable<User>> GetAllUsersAsync();
 

--- a/Services/MemoryUserService.cs
+++ b/Services/MemoryUserService.cs
@@ -1,4 +1,5 @@
 using UserApi.Models;
+using UserApi.DTOs;
 
 namespace UserApi.Services {
     public class MemoryUserService : IUserService {
@@ -26,8 +27,8 @@ namespace UserApi.Services {
             _users.Add(adminGuid, adminUser);
             _logins.Add(adminUser.Login, adminGuid);
         }
-        public Task<User?> CreateUserAsync(string login, string password, string name, int gender, DateTime? birthday, bool isAdmin, string createdBy) {
-            if (_logins.ContainsKey(login)) {
+        public Task<User?> CreateUserAsync(CreateUserRequestDto createUserDto, string createdBy) {
+            if (_logins.ContainsKey(createUserDto.Login)) {
                 Console.WriteLine("This login is already taken");
                 return Task.FromResult<User?>(null);
             }
@@ -35,12 +36,12 @@ namespace UserApi.Services {
             var newUserGuid = Guid.NewGuid();
             var newUser = new User {
                 Guid = newUserGuid,
-                Login = login,
-                Password = password, // todo: хешировать пароль
-                Name = name,
-                Gender = gender,
-                Birthday = birthday,
-                Admin = isAdmin,
+                Login = createUserDto.Login,
+                Password = createUserDto.Password, // todo: хешировать пароль
+                Name = createUserDto.Name,
+                Gender = createUserDto.Gender,
+                Birthday = createUserDto.Birthday,
+                Admin = createUserDto.Admin,
                 CreatedOn = DateTime.UtcNow,
                 CreatedBy = createdBy,
                 ModifiedOn = DateTime.UtcNow,
@@ -56,7 +57,7 @@ namespace UserApi.Services {
         }
 
         public Task<IEnumerable<User>> GetAllUsersAsync() {
-            return Task.FromResult(_users.Values.ToList() as IEnumerable<User>);
+            return Task.FromResult(_users.Values.Where(u => u.RevokedOn == null).OrderBy(u => u.CreatedOn).AsEnumerable());
         }
 
         public Task<User?> GetUserByLoginAsync(string login) {


### PR DESCRIPTION
In this pool request I implemented the function of creating new users. Now you can send a POST request to /api/users with user data and the system will create it. I've taken care of checking the incoming data: CreateUserRequestDto is used, which makes sure that the login is unique, has all the required fields, their length and formatting

If all is well, the user is assigned a unique ID, the date and author of creation are recorded, and in response the API gives 201 Created along with information about the new user (of course, without a password and indicating whether he is active) via UserResponseDto. If the login already exists or the data has not been validated, the server will return 400 Bad Request

At the same time I improved MemoryUserService: the GetAllUsersAsync method now correctly filters users, leaving only active ones, and sorts them by creation date, as required
