### PR TITLE
Update GET user endpoints to return UserResponseDto

### DIFF
--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -18,6 +18,10 @@ namespace UserApi.Controllers {
         public async Task<ActionResult<IEnumerable<UserResponseDto>>> GetAllUsers() {
             var users = await _userService.GetAllUsersAsync();
 
+            if (users == null) {
+                return Ok(Enumerable.Empty<UserResponseDto>());
+            }
+
             var userResponseDtos = users.Select(user => new UserResponseDto {
                 Guid = user.Guid,
                 Login = user.Login,
@@ -28,7 +32,7 @@ namespace UserApi.Controllers {
                 CreatedOn = user.CreatedOn,
                 IsActive = user.RevokedOn == null
             });
-            return Ok(users);
+            return Ok(userResponseDtos);
         }
 
         // GET: api/users/{login}

--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -15,20 +15,42 @@ namespace UserApi.Controllers {
 
         // GET: api/users
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<User>>> GetAllUsers() {
+        public async Task<ActionResult<IEnumerable<UserResponseDto>>> GetAllUsers() {
             var users = await _userService.GetAllUsersAsync();
-            return Ok(users); // todo: переделать в DTO ответа
+
+            var userResponseDtos = users.Select(user => new UserResponseDto {
+                Guid = user.Guid,
+                Login = user.Login,
+                Name = user.Name,
+                Gender = user.Gender,
+                Birthday = user.Birthday,
+                Admin = user.Admin,
+                CreatedOn = user.CreatedOn,
+                IsActive = user.RevokedOn == null
+            });
+            return Ok(users);
         }
 
         // GET: api/users/{login}
         [HttpGet("{login}")] 
-        public async Task<ActionResult<User>> GetUserByLogin([FromRoute] string login) {
+        public async Task<ActionResult<UserResponseDto>> GetUserByLogin([FromRoute] string login) {
             var user = await _userService.GetUserByLoginAsync(login);
             
             if (user == null) {
                 return NotFound();
             }
-            return Ok(user); // todo: переделать в DTO ответа
+
+            var userResponseDto = new UserResponseDto {
+                Guid = user.Guid,
+                Login = user.Login,
+                Name = user.Name,
+                Gender = user.Gender,
+                Birthday = user.Birthday,
+                Admin = user.Admin,
+                CreatedOn = user.CreatedOn,
+                IsActive = user.RevokedOn == null
+            };
+            return Ok(userResponseDto);
         }
 
         // POST: api/users


### PR DESCRIPTION
Now endpoints to retrieve user information (GET /api/users and GET /api/users/{login}) return UserResponseDto instead of the full User model. This is done to avoid giving out unnecessary internal fields and, of course, sensitive data like passwords. At the same time, the API has become more uniform and secure