### PR TITLE
Realize user restore functions

### DIFF
--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -171,5 +171,30 @@ namespace UserApi.Controllers {
             }
 
         }
+
+        // PUT: api/users/{login}/restore
+        [HttpPut("{login}/restore")]
+        public async Task<IActionResult> RestoreUser([FromRoute] string login) {
+            try {
+                string modifiedByLogin = "Admin"; // TODO: изменить на логин аутентифицированного админа
+                var restoredUser = await _userService.RestoreUserAsync(login, modifiedByLogin);
+
+                var userResponseDto = new UserResponseDto {
+                    Guid = restoredUser.Guid,
+                    Login = restoredUser.Login,
+                    Name = restoredUser.Name,
+                    Gender = restoredUser.Gender,
+                    Birthday = restoredUser.Birthday,
+                    Admin = restoredUser.Admin,
+                    CreatedOn = restoredUser.CreatedOn,
+                    IsActive = restoredUser.RevokedOn == null
+                };
+                
+                return Ok(userResponseDto);
+            }
+            catch (UserNotFoundException ex) {
+                return NotFound(new {message = ex.Message});
+            }
+        }
     }
 }

--- a/Services/IUserService.cs
+++ b/Services/IUserService.cs
@@ -18,5 +18,7 @@ namespace UserApi.Services
         Task<User> UpdateUserLoginAsync(string oldLogin, string newLogin, string modifiedBy);
 
         Task<User> SoftDeleteUserAsync(string login, string revokedByLogin);
+
+        Task<User> RestoreUserAsync(string login, string modifiedByLogin);
     }
 }

--- a/Services/MemoryUserService.cs
+++ b/Services/MemoryUserService.cs
@@ -173,5 +173,23 @@ namespace UserApi.Services {
 
             return await Task.FromResult(user);
         }
+
+        public async Task<User> RestoreUserAsync(string login, string modifiedByLogin) {
+            User? user = await GetUserByLoginAsync(login);
+            if (user == null) {
+                throw new UserNotFoundException(login);
+            }
+
+            if (user.RevokedOn != null) {
+                user.RevokedOn = null;
+                user.RevokedBy = null;
+            }
+
+            user.ModifiedBy = modifiedByLogin;
+            user.ModifiedOn = DateTime.UtcNow;
+
+            return await Task.FromResult(user);
+
+        }
     }
 }


### PR DESCRIPTION
In this Pull Request, I added the ability to restore previously “soft deleted” users. Implemented a PUT /api/users/{login}/restore endpoint that clears the RevokedOn and RevokedBy fields, and updates ModifiedOn and ModifiedBy. Corresponding changes have been made to the service layer and the IUserService interface