### PR TITLE
Add endpoint to get users older than a specified age

### DIFF
--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -158,6 +158,26 @@ namespace UserApi.Controllers {
             }
         }
 
+        // GET: api/users/older-than/{age}
+        // [Authorize(Roles = "Admin")] 
+        // TODO: расскоментировать после создания аутентификации
+        [HttpGet("older-than/{age}")]
+        public async Task<ActionResult<IEnumerable<UserResponseDto>>> GetUsersOlderThan([FromRoute] int age) {
+            if (age <= 0) {
+                return BadRequest(new { message = "Age can't be a negative" });
+            }
+
+            string requestedByLogin = "Admin"; // TODO: заменить после аутентификации
+            var users = await _userService.GetUsersOlderThanAsync(age, requestedByLogin);
+
+            if (users == null || !users.Any()) {
+                return Ok(Enumerable.Empty<UserResponseDto>());
+            }
+
+            var userResponseDtos = users.Select(u => MapUserToResponseDto(u));
+            return Ok(userResponseDtos);
+        }
+
         private UserResponseDto MapUserToResponseDto(User user) {
             return new UserResponseDto {
                 Guid = user.Guid,

--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -170,7 +170,7 @@ namespace UserApi.Controllers {
             string requestedByLogin = "Admin"; // TODO: заменить после аутентификации
             var users = await _userService.GetUsersOlderThanAsync(age, requestedByLogin);
 
-            if (users == null || !users.Any()) {
+            if (!users.Any()) {
                 return Ok(Enumerable.Empty<UserResponseDto>());
             }
 

--- a/Services/IUserService.cs
+++ b/Services/IUserService.cs
@@ -20,5 +20,7 @@ namespace UserApi.Services
         Task<User> SoftDeleteUserAsync(string login, string revokedByLogin);
 
         Task<User> RestoreUserAsync(string login, string modifiedByLogin);
+
+        Task<IEnumerable<User>> GetUsersOlderThanAsync(int age, string requestedByLogin);
     }
 }

--- a/Services/MemoryUserService.cs
+++ b/Services/MemoryUserService.cs
@@ -178,5 +178,13 @@ namespace UserApi.Services {
 
             return await Task.FromResult(user);
         }
+
+        public async Task<IEnumerable<User>> GetUsersOlderThanAsync(int age, string requestedByLogin) {
+            // TODO: использовать requestedByLogin при авторизации
+            var today = DateTime.UtcNow.Date;
+            var usersOlderThanAge = _users.Values.Where(u => u.RevokedOn == null && u.Birthday != null && u.Birthday.Value.AddYears(age) < today).OrderBy(u => u.CreatedOn).AsEnumerable();
+
+            return await Task.FromResult(usersOlderThanAge);
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces a new API endpoint GET /api/users/older-than/{age} that allows administrators to retrieve a list of active users older than the specified age. The returned list is sorted by user creation date. The implementation includes a new method in the user service to handle the business logic and updates to the controller to expose this functionality