### PR TITLE
Implement user self-retrieval, hard delete

### DIFF
--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -178,6 +178,21 @@ namespace UserApi.Controllers {
             return Ok(userResponseDtos);
         }
 
+        // POST: api/users/authenticate-details
+        [HttpPost("authenticate-details")]
+        public async Task<ActionResult<UserResponseDto>> GetSelftUserDetails([FromBody] UserCredentialsRequestDto credentialsDto) {
+            if (!ModelState.IsValid) {
+                return BadRequest(ModelState);
+            }
+
+            var user = await _userService.GetActiveUserByCredentialsAsync(credentialsDto.Login, credentialsDto.Password);
+            if (user == null) {
+                return Unauthorized(new { message = "Invalid login or password, or user is inactive" });
+            }
+
+            return Ok(MapUserToResponseDto(user));
+        }
+
         private UserResponseDto MapUserToResponseDto(User user) {
             return new UserResponseDto {
                 Guid = user.Guid,

--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -130,18 +130,23 @@ namespace UserApi.Controllers {
             }
         }
 
-        // DELETE: api/users/{login}
+        // DELETE: api/users/{login}?type={soft|hard}
+        // [Authorize(Roles = "Admin")] // TODO: раскомментировать после настройки аутентификации
         [HttpDelete("{login}")]
-        public async Task<IActionResult> SoftDeleteUser([FromRoute] string login) {
+        public async Task<IActionResult> DeleteUser([FromRoute] string login, [FromQuery] string type = "soft") {
             try {
-                string revokedByLogin = "Admin"; // TODO: изменить на логин аутентифицированного админа
-                await _userService.SoftDeleteUserAsync(login, revokedByLogin);
+                string deletedByLogin = "Admin"; // TODO: изменить на логин аутентифицированного админа
+                if ("hard".Equals(type, StringComparison.OrdinalIgnoreCase)) {
+                    await _userService.HardDeleteUserAsync(login, deletedByLogin);
+                }
+                else {
+                    await _userService.SoftDeleteUserAsync(login, deletedByLogin);
+                }
                 return NoContent();
             }
             catch (UserNotFoundException ex) {
                 return NotFound(new { message = ex.Message });
             }
-
         }
 
         // PUT: api/users/{login}/restore

--- a/DTOs/CreateUserRequestDto.cs
+++ b/DTOs/CreateUserRequestDto.cs
@@ -14,8 +14,8 @@ namespace UserApi.DTOs {
         public required string Password { get; set; }
 
         [Required(ErrorMessage = "Name is required")]
-        [StringLength(40, ErrorMessage = "Name cannot be longer than 100 characters")]
-        [RegularExpression(@"^[a-zA-Zа-яА-ЯёЁ\s]*$", ErrorMessage = "Name can only contain latin and cyrillic letters and spaces")]
+        [StringLength(40, ErrorMessage = "Name cannot be longer than 40 characters")]
+        [RegularExpression(@"^[a-zA-Zа-яА-ЯёЁ]*$", ErrorMessage = "Name can only contain latin and cyrillic letters")]
         public required string Name { get; set; }
 
         [Required(ErrorMessage = "Gender is required")]

--- a/DTOs/UpdateUserInfoRequestDto.cs
+++ b/DTOs/UpdateUserInfoRequestDto.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations;
 namespace UserApi.DTOs {
     public class UpdateUserInfoRequestDto {
         [StringLength(40, ErrorMessage = "Name cannot be longer than 40 characters")]
-        [RegularExpression(@"^[a-zA-Zа-яА-ЯёЁ\s]*$", ErrorMessage = "Name can only contain latin and cyrillic letters and spaces")]
+        [RegularExpression(@"^[a-zA-Zа-яА-ЯёЁ]*$", ErrorMessage = "Name can only contain latin and cyrillic letters")]
         public string? Name { get; set; }
 
         [Range(0, 2, ErrorMessage = "Gender must be 0, 1 or 2")]

--- a/DTOs/UserCredentialsRequestDto.cs
+++ b/DTOs/UserCredentialsRequestDto.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace UserApi.DTOs {
+    public class UserCredentialsRequestDto {
+        [Required(ErrorMessage = "Login is required")]
+        [StringLength(40, MinimumLength = 3, ErrorMessage = "Login must be between 3 and 40 characters")]
+        [RegularExpression("^[a-zA-Z0-9]*$", ErrorMessage = "Login can only contain latin letters and numbers")]
+        public required string Login { get; set; }
+
+        [Required(ErrorMessage = "Password is required")]
+        [StringLength(80, MinimumLength = 5, ErrorMessage = "Password must be between 5 and 80 characters")]
+        [RegularExpression("^[a-zA-Z0-9]*$", ErrorMessage = "Password can only contain latin letters and numbers")]
+        public required string Password { get; set; }
+        
+    }
+}

--- a/Services/IUserService.cs
+++ b/Services/IUserService.cs
@@ -19,6 +19,8 @@ namespace UserApi.Services
 
         Task<User> SoftDeleteUserAsync(string login, string revokedByLogin);
 
+        Task HardDeleteUserAsync(string login, string deletedByLogin);
+
         Task<User> RestoreUserAsync(string login, string modifiedByLogin);
 
         Task<IEnumerable<User>> GetUsersOlderThanAsync(int age, string requestedByLogin);

--- a/Services/IUserService.cs
+++ b/Services/IUserService.cs
@@ -22,5 +22,7 @@ namespace UserApi.Services
         Task<User> RestoreUserAsync(string login, string modifiedByLogin);
 
         Task<IEnumerable<User>> GetUsersOlderThanAsync(int age, string requestedByLogin);
+
+        Task<User?> GetActiveUserByCredentialsAsync(string login, string password);
     }
 }

--- a/Services/MemoryUserService.cs
+++ b/Services/MemoryUserService.cs
@@ -166,6 +166,13 @@ namespace UserApi.Services {
             return await Task.FromResult(user);
         }
 
+        public async Task HardDeleteUserAsync(string login, string deletedByLogin) {
+            var user = await GetUserByLoginOrThrowAsync(login);
+
+            _users.Remove(user.Guid);
+            _logins.Remove(user.Login);
+        }
+
         public async Task<User> RestoreUserAsync(string login, string modifiedByLogin) {
             User user = await GetUserByLoginOrThrowAsync(login);
 

--- a/Services/MemoryUserService.cs
+++ b/Services/MemoryUserService.cs
@@ -186,5 +186,19 @@ namespace UserApi.Services {
 
             return await Task.FromResult(usersOlderThanAge);
         }
+
+        public async Task<User?> GetActiveUserByCredentialsAsync(string login, string password) {
+            var user = await GetUserByLoginAsync(login);
+
+            if (user == null || user.RevokedOn != null) {
+                return null;
+            }
+
+            bool isValidPassword = PasswordHasher.IsMatchPasswords(password, user.PasswordHash, user.PasswordSalt, user.PasswordIterations, user.PasswordHashAlgorithm);
+            if (!isValidPassword) {
+                return null;
+            }
+            return user; // TODO: возможно стоит обернуть в FromResult
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces two significant enhancements to user management functionality, completed prior to the implementation of authentication. Firstly, it adds a new endpoint that allows users to securely retrieve their own account details by providing their login credentials. Secondly, the existing user deletion mechanism has been upgraded to support permanent (hard) deletion of users through a query parameter, complementing the current soft delete feature. These updates also incorporate further refinements to the validation rules for key user data fields